### PR TITLE
Fixed sass file class selector indentation

### DIFF
--- a/dist/css/bulma-floating-button.sass
+++ b/dist/css/bulma-floating-button.sass
@@ -10,17 +10,17 @@
   font-size: 1.6rem
   box-shadow: 0 .0625em .125em rgba($scheme-invert,.05)
   z-index: 3
-  .is-large
+  &.is-large
     width: 90px
     height: 90px
     font-size: 2.6rem
 
-  .is-medium
+  &.is-medium
     width: 75px
     height: 75px
     font-size: 2.2rem
 
-  .is-small
+  &.is-small
     width: 45px
     height: 45px
     font-size: 1.2rem

--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -10,17 +10,17 @@
   font-size: 1.6rem
   box-shadow: 0 .0625em .125em rgba($scheme-invert,.05)
   z-index: 3
-  .is-large
+  &.is-large
     width: 90px
     height: 90px
     font-size: 2.6rem
 
-  .is-medium
+  &.is-medium
     width: 75px
     height: 75px
     font-size: 2.2rem
 
-  .is-small
+  &.is-small
     width: 45px
     height: 45px
     font-size: 1.2rem


### PR DESCRIPTION
The class selector in the .sass files were wrong. The .min.sass files were correct (so they were not generated from the .sass files in the repo).

Here we can see the file with the error
![image](https://user-images.githubusercontent.com/8711030/162081911-0edef61f-30e1-44fb-90d3-08ab650fada6.png)

Here we can see the file with the fix
![image](https://user-images.githubusercontent.com/8711030/162081965-12ee034c-3279-4426-b514-bbc41c8f999a.png)
